### PR TITLE
Feat: 유저 대시보드 페이지 api 연동

### DIFF
--- a/app/dashboard/api/wallet-info.ts
+++ b/app/dashboard/api/wallet-info.ts
@@ -1,0 +1,18 @@
+import { getApiUrl } from "@/lib/getApiUrl";
+
+const API_URL = getApiUrl();
+
+export async function fetchWalletInfo(accessToken: string) {
+    const res = await fetch(`${API_URL}/api/users/wallet`, {
+        method: "GET",
+        headers: {
+            Authorization: `Bearer ${accessToken}`,
+        },
+        credentials: "include",
+    });
+
+    if (!res.ok) throw new Error("지갑 정보를 불러오지 못했습니다.");
+
+    const data = await res.json();
+    return data.result;
+}

--- a/app/dashboard/componenets/WalletCard.tsx
+++ b/app/dashboard/componenets/WalletCard.tsx
@@ -6,10 +6,12 @@ import { Button } from "@/components/ui/button"
 import { useRouter } from "next/navigation"
 
 interface WalletCardProps {
-    userName: string
+    userName: string;
+    accountNumber: string;
+    tokenBalance: number;
 }
 
-export default function WalletCard({ userName }: WalletCardProps) {
+export default function WalletCard({ userName, accountNumber, tokenBalance }: WalletCardProps) {
     const router = useRouter()
 
     return (
@@ -33,7 +35,7 @@ export default function WalletCard({ userName }: WalletCardProps) {
                     </div>
                     <div>
                         <p className="text-sm font-medium text-white">{userName} 님의 지갑</p>
-                        <p className="text-xs text-white/80 font-light">1020-9564-9584</p>
+                        <p className="text-xs text-white/80 font-light">{accountNumber}</p>
                     </div>
                 </div>
 
@@ -42,7 +44,7 @@ export default function WalletCard({ userName }: WalletCardProps) {
                     <div className="min-w-0">
                         <p className="text-xs text-white/80 font-light">예금 토큰 잔액</p>
                         <div className="flex items-baseline mt-1">
-                            <p className="text-[28px] sm:text-3xl font-bold text-white truncate max-w-[160px]">1,000,000</p>
+                            <p className="text-[28px] sm:text-3xl font-bold text-white truncate max-w-[160px]">{tokenBalance.toLocaleString()}</p>
                             <p className="ml-1 text-lg text-white/90">원</p>
                         </div>
                     </div>

--- a/components/common/WithAuth.tsx
+++ b/components/common/WithAuth.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+export default function withAuth<P extends object>(WrappedComponent: React.ComponentType<P>) {
+    return function ProtectedComponent(props: P) {
+        const router = useRouter();
+
+        useEffect(() => {
+            const accessToken = getCookie("accessToken");
+
+            // 토큰 없으면 로그인으로
+            if (!accessToken) {
+                router.replace("/login");
+            }
+        }, []);
+
+        return <WrappedComponent {...props} />;
+    };
+}
+
+function getCookie(name: string): string | null {
+    if (typeof document === "undefined") return null;
+    const match = document.cookie.match(new RegExp("(^| )" + name + "=([^;]+)"));
+    return match ? match[2] : null;
+}

--- a/lib/cookies.ts
+++ b/lib/cookies.ts
@@ -1,0 +1,6 @@
+export function getCookie(name: string): string | null {
+    if (typeof document === "undefined") return null;
+
+    const match = document.cookie.match(new RegExp("(^| )" + name + "=([^;]+)"));
+    return match ? decodeURIComponent(match[2]) : null;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
 // 보호 경로 설정
-const protectedPaths = ["/dashboard", "/mypage", "/notice", "/offline-stores"];
+const protectedPaths = ["/dashboard", "/mypage"];
 
 export function middleware(request: NextRequest) {
     const token = request.cookies.get("accessToken");
@@ -20,5 +20,5 @@ export function middleware(request: NextRequest) {
 
 // matcher 설정
 export const config = {
-    matcher: ["/dashboard/:path*", "/mypage/:path*", "/wallet/:path*"],
+    matcher: ["/dashboard/:path*", "/mypage/:path*"],
 };

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+// 보호 경로 설정
+const protectedPaths = ["/dashboard", "/mypage", "/notice", "/offline-stores"];
+
+export function middleware(request: NextRequest) {
+    const token = request.cookies.get("accessToken");
+
+    const pathname = request.nextUrl.pathname;
+
+    const isProtected = protectedPaths.some((path) => pathname.startsWith(path));
+
+    if (isProtected && !token) {
+        return NextResponse.redirect(new URL("/login", request.url));
+    }
+
+    return NextResponse.next();
+}
+
+// matcher 설정
+export const config = {
+    matcher: ["/dashboard/:path*", "/mypage/:path*", "/wallet/:path*"],
+};


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #

## 📌 개요
- 유저 대시보드 페이지의 지갑 컴포넌트 api 연동
- 허용한 경로 이외에 쿠키에 토큰 값이 없을 시 로그인으로 리다이렉트 되도록 설정(/components/common/WithAuth.ts, /middleware.ts)
- 쿠키 값을 가져오는 함수 구현(/lib/cookies.ts)

## 🔁 변경 사항

## 📸 스크린샷 (선택)
<img width="275" alt="image" src="https://github.com/user-attachments/assets/5e40c2ce-f9c3-4fcb-a9c4-386b5ee38b7a" />

대시보드의 위 컴포넌트에 대해서 연동 완료했습니다

## 👀 기타 더 이야기해볼 점 (선택)
middleware.ts 파일에서 제가 연동할 부분만 토큰에 대해서 설정해두었습니다
추후 다른 팀원들도 구현 완료되면 각 페이지에 적용하겠습니다!

## 💬 리뷰 요구사항 (선택)

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
